### PR TITLE
Add Vision Mamba VSS block and extras

### DIFF
--- a/H-vmunet-main/configs/config_setting.py
+++ b/H-vmunet-main/configs/config_setting.py
@@ -1,5 +1,6 @@
 from torchvision import transforms
 from utils import *
+from losses.cldice import CombinedLoss
 
 from datetime import datetime
 
@@ -29,7 +30,7 @@ class setting_config:
     else:
         raise Exception('datasets in not right!')
 
-    criterion = BceDiceLoss()
+    criterion = CombinedLoss(BceDiceLoss())
 
     num_classes = 1
     input_size_h = 256

--- a/H-vmunet-main/dataset/wavelet_mixup.py
+++ b/H-vmunet-main/dataset/wavelet_mixup.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pywt
+
+__all__ = ['wavelet_mixup']
+
+def wavelet_mixup(img1, img2, alpha=0.5):
+    coeffs1 = pywt.dwt2(img1, 'haar')
+    coeffs2 = pywt.dwt2(img2, 'haar')
+    mixed = []
+    for c1, c2 in zip(coeffs1, coeffs2):
+        if isinstance(c1, tuple):
+            mixed.append(tuple(alpha * a + (1 - alpha) * b for a, b in zip(c1, c2)))
+        else:
+            mixed.append(alpha * c1 + (1 - alpha) * c2)
+    return pywt.idwt2(tuple(mixed), 'haar')

--- a/H-vmunet-main/export.py
+++ b/H-vmunet-main/export.py
@@ -1,0 +1,55 @@
+import argparse
+import torch
+import onnx
+from torch.onnx import export
+from models.H_vmunet import H_vmunet
+from configs.config_setting import setting_config
+
+try:
+    import tensorrt as trt
+except Exception:
+    trt = None
+
+
+def export_int8(checkpoint, output, calib_dir):
+    model_cfg = setting_config.model_config
+    model = H_vmunet(num_classes=model_cfg['num_classes'],
+                     input_channels=model_cfg['input_channels'],
+                     c_list=model_cfg['c_list'],
+                     split_att=model_cfg['split_att'],
+                     bridge=model_cfg['bridge'],
+                     drop_path_rate=model_cfg['drop_path_rate'])
+    model.load_state_dict(torch.load(checkpoint, map_location='cpu'))
+    model.eval()
+
+    dummy = torch.randn(1, model_cfg['input_channels'], 256, 256)
+    onnx_path = output + '.onnx'
+    export(model, dummy, onnx_path, opset_version=17)
+
+    if trt is None:
+        print('TensorRT not available. ONNX model exported.')
+        return
+
+    logger = trt.Logger(trt.Logger.INFO)
+    builder = trt.Builder(logger)
+    network = builder.create_network(1)
+    parser = trt.OnnxParser(network, logger)
+    with open(onnx_path, 'rb') as f:
+        parser.parse(f.read())
+    config = builder.create_builder_config()
+    config.set_flag(trt.BuilderFlag.INT8)
+    config.max_workspace_size = 1 << 28
+    builder.max_batch_size = 1
+    engine = builder.build_engine(network, config)
+    with open(output + '.trt', 'wb') as f:
+        f.write(engine.serialize())
+    print('TensorRT engine saved to', output + '.trt')
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--checkpoint', required=True)
+    ap.add_argument('--output', required=True)
+    ap.add_argument('--calib', default='calib')
+    args = ap.parse_args()
+    export_int8(args.checkpoint, args.output, args.calib)

--- a/H-vmunet-main/losses/cldice.py
+++ b/H-vmunet-main/losses/cldice.py
@@ -1,0 +1,57 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class SoftDiceLoss(nn.Module):
+    def forward(self, input, target):
+        smooth = 1.0
+        input = input.contiguous().view(-1)
+        target = target.contiguous().view(-1)
+        intersection = (input * target).sum()
+        d = input.sum() + target.sum()
+        return 1 - (2 * intersection + smooth) / (d + smooth)
+
+class clDiceLoss(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dice = SoftDiceLoss()
+
+    def forward(self, pred, target):
+        pred_s = F.max_pool2d(pred, 3, 1, 1) - F.max_pool2d(-pred, 3, 1, 1)
+        target_s = F.max_pool2d(target, 3, 1, 1) - F.max_pool2d(-target, 3, 1, 1)
+        return self.dice(pred, target) + self.dice(pred_s, target_s)
+
+class cbDiceLoss(nn.Module):
+    def __init__(self, beta=1.0):
+        super().__init__()
+        self.beta = beta
+
+    def forward(self, pred, target):
+        pred = pred.contiguous().view(-1)
+        target = target.contiguous().view(-1)
+        tp = (pred * target).sum()
+        fp = (pred * (1 - target)).sum()
+        fn = ((1 - pred) * target).sum()
+        denom = tp + self.beta * fp + (1 - self.beta) * fn + 1e-6
+        return 1 - tp / denom
+
+
+class CombinedLoss(nn.Module):
+    """Combination of BCE-Dice, clDice and cbDice."""
+    def __init__(self, bce_dice, use_cl=True, use_cb=True):
+        super().__init__()
+        self.bce_dice = bce_dice
+        self.use_cl = use_cl
+        self.use_cb = use_cb
+        if use_cl:
+            self.cl = clDiceLoss()
+        if use_cb:
+            self.cb = cbDiceLoss()
+
+    def forward(self, pred, target):
+        loss = self.bce_dice(pred, target)
+        if self.use_cl:
+            loss = loss + self.cl(pred, target)
+        if self.use_cb:
+            loss = loss + self.cb(pred, target)
+        return loss

--- a/H-vmunet-main/models/ghost_dynconv.py
+++ b/H-vmunet-main/models/ghost_dynconv.py
@@ -1,0 +1,44 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+class GhostConv(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=1, ratio=2):
+        super().__init__()
+        init_channels = int(out_channels / ratio)
+        self.primary = nn.Conv2d(in_channels, init_channels, kernel_size, padding=kernel_size//2, bias=False)
+        self.cheap = nn.Conv2d(init_channels, out_channels - init_channels, 3, padding=1, groups=init_channels, bias=False)
+        self.bn = nn.BatchNorm2d(out_channels)
+
+    def forward(self, x):
+        y = self.primary(x)
+        y = torch.cat([y, self.cheap(y)], dim=1)
+        return self.bn(y)
+
+class KernelWarehouseDynConv(nn.Module):
+    def __init__(self, channels, kernels=4):
+        super().__init__()
+        self.kernels = kernels
+        self.weight = nn.Parameter(torch.randn(kernels, channels, 3, 3))
+        self.attn = nn.Conv2d(channels, kernels, 1)
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        attn = torch.softmax(self.attn(x), dim=1)
+        outs = []
+        for i in range(self.kernels):
+            conv = F.conv2d(x, self.weight[i:i+1], padding=1)
+            outs.append(conv * attn[:, i:i+1])
+        return sum(outs)
+
+class GhostDynConv(nn.Module):
+    """Combine GhostConv and KernelWarehouseDynConv."""
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.local = GhostConv(in_channels, out_channels)
+        self.global_branch = KernelWarehouseDynConv(out_channels)
+
+    def forward(self, x):
+        local_feat = self.local(x)
+        global_feat = self.global_branch(local_feat)
+        return local_feat + global_feat

--- a/H-vmunet-main/models/heads.py
+++ b/H-vmunet-main/models/heads.py
@@ -1,0 +1,24 @@
+import torch
+from torch import nn
+from .ghost_dynconv import GhostDynConv
+from .replk_lite import RepLKLiteBlock
+
+class HyperSpaceHead(nn.Module):
+    """Segmentation, edge and thickness heads sharing common backbone."""
+    def __init__(self, in_channels, num_classes=1, thickness_spacing=1.0):
+        super().__init__()
+        self.shared = nn.Sequential(
+            GhostDynConv(in_channels, in_channels),
+            RepLKLiteBlock(in_channels)
+        )
+        self.seg_head = nn.Conv2d(in_channels, num_classes, 1)
+        self.edge_head = nn.Conv2d(in_channels, 1, 1)
+        self.thick_head = nn.Conv2d(in_channels, 1, 1)
+        self.spacing = thickness_spacing
+
+    def forward(self, x):
+        feat = self.shared(x)
+        seg = torch.sigmoid(self.seg_head(feat))
+        edge = torch.sigmoid(self.edge_head(feat))
+        thickness = self.thick_head(feat) * self.spacing
+        return seg, edge, thickness

--- a/H-vmunet-main/models/replk_lite.py
+++ b/H-vmunet-main/models/replk_lite.py
@@ -1,0 +1,34 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class RepLKLiteBlock(nn.Module):
+    """RepLK-Lite Large-Kernel Block with re-parameterization"""
+    def __init__(self, channels, kernel_size=31):
+        super().__init__()
+        padding = kernel_size // 2
+        self.dw = nn.Conv2d(channels, channels, kernel_size, padding=padding, groups=channels, bias=False)
+        self.pw = nn.Conv2d(channels, channels, 1, bias=False)
+        self.bn = nn.BatchNorm2d(channels)
+        self.reparam = False
+
+    def forward(self, x):
+        if self.reparam:
+            return self.rep(x)
+        out = self.dw(x)
+        out = self.bn(out)
+        out = F.relu(out)
+        out = self.pw(out)
+        return out
+
+    def reparameterize(self):
+        weight = self.dw.weight + self.pw.weight.unsqueeze(-1).unsqueeze(-1)
+        self.rep = nn.Conv2d(self.dw.in_channels, self.dw.out_channels, self.dw.kernel_size,
+                             padding=self.dw.padding, bias=True)
+        self.rep.weight.data = weight
+        self.rep.bias = nn.Parameter(torch.zeros(self.dw.out_channels))
+        self.reparam = True
+        # remove old layers
+        del self.dw
+        del self.pw
+        del self.bn

--- a/H-vmunet-main/models/vss_block.py
+++ b/H-vmunet-main/models/vss_block.py
@@ -1,0 +1,37 @@
+import torch
+from torch import nn
+import torch.nn.functional as F
+from .vmamba import SS2D
+from .ghost_dynconv import GhostDynConv
+
+try:
+    from flash_attn.modules.mha import FlashSelfAttention
+    _flash_available = True
+except Exception:
+    _flash_available = False
+
+class VSSBlock(nn.Module):
+    """Vision-Mamba based block with optional FlashAttention."""
+    def __init__(self, dim):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.ssm = SS2D(d_model=dim)
+        if _flash_available:
+            self.attn = FlashSelfAttention()
+        else:
+            self.attn = None
+        self.conv = GhostDynConv(dim, dim)
+
+    def forward(self, x):
+        b, c, h, w = x.shape
+        residual = x
+        x = x.permute(0, 2, 3, 1)
+        x = self.norm(x)
+        x = self.ssm(x)
+        x = x.permute(0, 3, 1, 2)
+        if self.attn is not None:
+            q = x.flatten(2).transpose(1, 2)
+            attn_out = self.attn(q)
+            x = attn_out.transpose(1, 2).view(b, c, h, w)
+        x = self.conv(x)
+        return x + residual

--- a/H-vmunet-main/test.py
+++ b/H-vmunet-main/test.py
@@ -60,7 +60,7 @@ def main(config):
 
 
     print('#----------Preparing dataset----------#')
-    test_dataset = isic_loader(path_Data = config.data_path, train = False, Test = True)
+    test_dataset = RealSynthUSLoader(root=config.data_path, train=False)
     test_loader = DataLoader(test_dataset,
                                 batch_size=1,
                                 shuffle=False,

--- a/H-vmunet-main/train.py
+++ b/H-vmunet-main/train.py
@@ -48,24 +48,24 @@ def main(config):
 
 
     print('#----------Preparing dataset----------#')
-    train_dataset = isic_loader(path_Data = config.data_path, train = True)
+    train_dataset = RealSynthUSLoader(root=config.data_path, train=True)
     train_loader = DataLoader(train_dataset,
-                                batch_size=config.batch_size, 
+                                batch_size=config.batch_size,
                                 shuffle=True,
                                 pin_memory=True,
                                 num_workers=config.num_workers)
-    val_dataset = isic_loader(path_Data = config.data_path, train = False)
+    val_dataset = RealSynthUSLoader(root=config.data_path, train=False)
     val_loader = DataLoader(val_dataset,
                                 batch_size=1,
                                 shuffle=False,
-                                pin_memory=True, 
+                                pin_memory=True,
                                 num_workers=config.num_workers,
                                 drop_last=True)
-    test_dataset = isic_loader(path_Data = config.data_path, train = False, Test = True)
+    test_dataset = RealSynthUSLoader(root=config.data_path, train=False)
     test_loader = DataLoader(test_dataset,
                                 batch_size=1,
                                 shuffle=False,
-                                pin_memory=True, 
+                                pin_memory=True,
                                 num_workers=config.num_workers,
                                 drop_last=True)
 


### PR DESCRIPTION
## Summary
- add VSSBlock built on vision-mamba with optional FlashAttention
- introduce GhostDynConv, RepLK-Lite block and HyperSpaceHead modules
- include clDice/cbDice losses with CombinedLoss wrapper
- enhance loader with Real+LDM dataset and Wavelet-MixUp
- update training/testing to use new dataset and combined criterion
- provide export script for ONNX/TensorRT

## Testing
- `python -m py_compile H-vmunet-main/models/ghost_dynconv.py H-vmunet-main/models/replk_lite.py H-vmunet-main/models/vss_block.py H-vmunet-main/models/heads.py H-vmunet-main/losses/cldice.py H-vmunet-main/dataset/wavelet_mixup.py H-vmunet-main/train.py H-vmunet-main/test.py H-vmunet-main/export.py H-vmunet-main/loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68405051c000832483bf02bc8382225a