### PR TITLE
Run minimal PennFudan training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+data/
+__pycache__/
+H-vmunet-main/**/__pycache__/
+H-vmunet-main/results/

--- a/H-vmunet-main/configs/config_setting.py
+++ b/H-vmunet-main/configs/config_setting.py
@@ -20,13 +20,9 @@ class setting_config:
 
     test_weights = ''
 
-    datasets = 'ISIC2017'
-    if datasets == 'ISIC2017':
-        data_path = ''
-    elif datasets == 'Spleen':
-        data_path = ''
-    elif datasets == 'CVC-ClinicDB':
-        data_path = ''
+    datasets = 'PennFudan'
+    if datasets == 'PennFudan':
+        data_path = 'data/seg_dataset/'
     else:
         raise Exception('datasets in not right!')
 
@@ -44,8 +40,8 @@ class setting_config:
     world_size = None
     rank = None
     amp = False
-    batch_size = 8
-    epochs = 250
+    batch_size = 2
+    epochs = 2
 
     work_dir = 'results/' + network + '_' + datasets + '_' + datetime.now().strftime('%A_%d_%B_%Y_%Hh_%Mm_%Ss') + '/'
 

--- a/H-vmunet-main/dataprepare/prepare_pennfudan.py
+++ b/H-vmunet-main/dataprepare/prepare_pennfudan.py
@@ -1,0 +1,55 @@
+import os
+import numpy as np
+from PIL import Image
+import random
+
+height = 256
+width = 256
+channels = 3
+
+random_seed = 42
+
+images_dir = os.path.join(os.path.dirname(__file__), '..', 'data', 'your_dataset', 'images')
+masks_dir = os.path.join(os.path.dirname(__file__), '..', 'data', 'your_dataset', 'masks')
+
+image_files = sorted([f for f in os.listdir(images_dir) if f.endswith('.png')])
+random.Random(random_seed).shuffle(image_files)
+
+all_imgs = []
+all_masks = []
+for fname in image_files:
+    img = Image.open(os.path.join(images_dir, fname)).convert('RGB').resize((width, height))
+    mask_name = os.path.splitext(fname)[0] + '_mask.png'
+    mask = Image.open(os.path.join(masks_dir, mask_name)).convert('L').resize((width, height))
+    mask = np.array(mask, dtype=np.float32)
+    mask = np.where(mask > 0, 255.0, 0.0)
+    all_imgs.append(np.asarray(img, dtype=np.float32))
+    all_masks.append(mask)
+
+all_imgs = np.stack(all_imgs)
+all_masks = np.stack(all_masks)
+
+all_imgs = (all_imgs - all_imgs.min()) / (all_imgs.max() - all_imgs.min()) * 255
+
+n_total = len(all_imgs)
+train_n = int(0.6 * n_total)
+val_n = int(0.2 * n_total)
+
+train_img = all_imgs[:train_n]
+val_img = all_imgs[train_n:train_n+val_n]
+test_img = all_imgs[train_n+val_n:]
+
+train_mask = all_masks[:train_n]
+val_mask = all_masks[train_n:train_n+val_n]
+test_mask = all_masks[train_n+val_n:]
+
+out_dir = os.path.join(os.path.dirname(__file__), '..', 'data', 'pennfudan_npy')
+os.makedirs(out_dir, exist_ok=True)
+np.save(os.path.join(out_dir, 'data_train.npy'), train_img)
+np.save(os.path.join(out_dir, 'data_val.npy'), val_img)
+np.save(os.path.join(out_dir, 'data_test.npy'), test_img)
+np.save(os.path.join(out_dir, 'mask_train.npy'), train_mask)
+np.save(os.path.join(out_dir, 'mask_val.npy'), val_mask)
+np.save(os.path.join(out_dir, 'mask_test.npy'), test_mask)
+
+print('Prepared dataset saved to', out_dir)

--- a/H-vmunet-main/dataset/wavelet_mixup.py
+++ b/H-vmunet-main/dataset/wavelet_mixup.py
@@ -1,15 +1,6 @@
 import numpy as np
-import pywt
 
 __all__ = ['wavelet_mixup']
 
 def wavelet_mixup(img1, img2, alpha=0.5):
-    coeffs1 = pywt.dwt2(img1, 'haar')
-    coeffs2 = pywt.dwt2(img2, 'haar')
-    mixed = []
-    for c1, c2 in zip(coeffs1, coeffs2):
-        if isinstance(c1, tuple):
-            mixed.append(tuple(alpha * a + (1 - alpha) * b for a, b in zip(c1, c2)))
-        else:
-            mixed.append(alpha * c1 + (1 - alpha) * c2)
-    return pywt.idwt2(tuple(mixed), 'haar')
+    return alpha * img1 + (1 - alpha) * img2

--- a/H-vmunet-main/loader.py
+++ b/H-vmunet-main/loader.py
@@ -5,10 +5,9 @@ import random
 import os
 from PIL import Image
 from einops.layers.torch import Rearrange
-from scipy.ndimage.morphology import binary_dilation
 from torch.utils.data import Dataset
 from torchvision import transforms
-from scipy import ndimage
+from PIL import Image as PILImage
 from utils import *
 
 
@@ -72,8 +71,11 @@ class isic_loader(Dataset):
     
     def random_rotate(self,image, label):
         angle = np.random.randint(20, 80)
-        image = ndimage.rotate(image, angle, order=0, reshape=False)
-        label = ndimage.rotate(label, angle, order=0, reshape=False)
+        img_pil = PILImage.fromarray(image.astype(np.uint8))
+        label_pil = PILImage.fromarray(np.squeeze(label).astype(np.uint8), mode='L')
+        image = np.array(img_pil.rotate(angle))
+        label = np.array(label_pil.rotate(angle))
+        label = np.expand_dims(label, axis=2)
         return image, label
 
 


### PR DESCRIPTION
## Summary
- add dataset preparation for the PennFudan Pedestrian segmentation dataset
- adjust configuration for PennFudan data and quick CPU execution
- remove heavy matplotlib/scipy usage
- implement simple mixup and rotation without scipy

## Testing
- `python dataprepare/prepare_pennfudan.py`
- `python train.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a39cb3d88324bca108db281bdbab