### PR TITLE
Enable GPU support

### DIFF
--- a/H-vmunet-main/README.md
+++ b/H-vmunet-main/README.md
@@ -20,6 +20,12 @@ pip install mamba_ssm==1.0.1  # mmamba_ssm-1.0.1+cu118torch1.13cxx11abiFALSE-cp3
 pip install scikit-learn matplotlib thop h5py SimpleITK scikit-image medpy yacs
 ```
 
+**Using CUDA for training.**
+After installing the GPU-enabled PyTorch above, edit `configs/config_setting.py`
+and set `device = 'cuda'`. If multiple GPUs are available, modify
+`CUDA_VISIBLE_DEVICES` in `train.py` and `test.py` (default is `"0"`) or export
+the environment variable before running.
+
 **1. Datasets.**
 
 *A.ISIC2017* </br>

--- a/H-vmunet-main/configs/config_setting.py
+++ b/H-vmunet-main/configs/config_setting.py
@@ -36,7 +36,7 @@ class setting_config:
     local_rank = -1
     num_workers = 0
     seed = 42
-    device = 'cpu'
+    device = 'cuda'
     world_size = None
     rank = None
     amp = False


### PR DESCRIPTION
## Summary
- guide users to run training with CUDA in README
- default to CUDA device in config

## Testing
- `pyright H-vmunet-main/configs/config_setting.py`

------
https://chatgpt.com/codex/tasks/task_e_6841aad710f08324b9701c27f43c1651